### PR TITLE
createjar: make sure bin directory exists before attempting to clean it

### DIFF
--- a/createjar.xml
+++ b/createjar.xml
@@ -6,6 +6,7 @@
 
         <!-- First, clean the bin directory -->
         <echo message="Cleanup up the bin dir..."/>
+        <mkdir dir="bin"/>
         <delete includeemptydirs="true">
             <fileset dir="bin" includes="**/*"/>
         </delete>


### PR DESCRIPTION
Signed-off-by: Chirayu Desai cdesai@cyanogenmod.org
