### PR TITLE
Locks

### DIFF
--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Analyzer.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Analyzer.java
@@ -283,17 +283,17 @@ import java.util.Vector;
                 .add(new Bold(procNames.toString()))
                 .add(" has/have a deadlock involving the following threads (from \"")
                 .add(procList.get(0).getGroup().getName() + "\"):");
-            listThreads(br, msg, deadlock);
+            listThreads(br, msg, deadlock, null);
             if (blocked.size() > 0) {
                 new Para(msg).add("Additionally the following threads are blocked due to this deadlock:");
-                listThreads(br, msg, blocked);
+                listThreads(br, msg, blocked, deadlock);
             }
             br.addBug(bug);
         }
 
     }
 
-    private void listThreads(BugReportModule br, DocNode msg, Vector<StackTrace> list) {
+    private void listThreads(BugReportModule br, DocNode msg, Vector<StackTrace> list, Vector<StackTrace> referenceList) {
         List l = new List(List.TYPE_UNORDERED, msg);
         for (StackTrace stack : list) {
             Process p = stack.getProcess();
@@ -301,6 +301,15 @@ import java.util.Vector;
             li.add(new ProcessLink(br, p.getPid()));
             li.add(" / ");
             li.add(new Link(stack.getAnchor(), stack.getName()));
+            if (stack.getWaitOn() > 0 && referenceList != null) {
+                for (StackTrace s : referenceList) {
+                    if (s.getTid() == stack.getWaitOn()) {
+                        li.add("  waiting:");
+                        li.add(new Link(s.getAnchor(), s.getName()));
+                        break;
+                    }
+                }
+            }
         }
     }
 

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Analyzer.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Analyzer.java
@@ -304,7 +304,7 @@ import java.util.Vector;
             if (stack.getWaitOn() > 0 && referenceList != null) {
                 for (StackTrace s : referenceList) {
                     if (s.getTid() == stack.getWaitOn()) {
-                        li.add("  waiting:");
+                        li.add("  waiting: ");
                         li.add(new Link(s.getAnchor(), s.getName()));
                         break;
                     }

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -22,6 +22,8 @@ package com.sonyericsson.chkbugreport.plugins.stacktrace;
 import com.sonyericsson.chkbugreport.BugReportModule;
 import com.sonyericsson.chkbugreport.Section;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -116,16 +118,21 @@ import java.util.regex.Pattern;
                     } else if (buff.startsWith("  - ")) {
                         buff = buff.substring(4);
                         if (buff.startsWith("waiting ")) {
-                            String needle = "held by threadid=";
-                            int idx = buff.indexOf(needle);
-                            if (idx < 0) {
-                                // try new variant
-                                needle = "held by tid=";
-                                idx = buff.indexOf(needle);
+                            int idx = -1;
+                            String needle = "";
+                            for (String possibleNeedle : getPossibleWaitingNeedles()) {
+                                idx = buff.indexOf(possibleNeedle);
+                                if (idx > 0) {
+                                    needle = possibleNeedle;
+                                    break;
+                                }
                             }
                             if (idx > 0) {
                                 idx += needle.length();
                                 int idx2 = buff.indexOf(' ', idx);
+                                if (idx2 < 0) {
+                                    idx2 = buff.length();
+                                }
                                 if (idx2 > 0) {
                                     int tid = Integer.parseInt(buff.substring(idx, idx2));
                                     if (tid != curStackTrace.getTid()) {
@@ -173,6 +180,14 @@ import java.util.regex.Pattern;
 
         }
         return processes;
+    }
+
+    private Iterable<String> getPossibleWaitingNeedles() {
+        List<String> list = new ArrayList<String>();
+        list.add("held by threadid=");
+        list.add("held by tid=");
+        list.add("held by thread ");
+        return list;
     }
 
 }

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -117,6 +117,8 @@ import java.util.regex.Pattern;
                         curStackTrace.parseProperties(buff.substring(4));
                     } else if (buff.startsWith("  - ")) {
                         buff = buff.substring(4);
+                        StackTraceItem item = new StackTraceItem("", buff, 0);
+                        curStackTrace.addStackTraceItem(item);
                         if (buff.startsWith("waiting ")) {
                             int idx = -1;
                             String needle = "";


### PR DESCRIPTION
3 things:
* Add new waiting format variant so that deadlock detection works with current android traces.
* Add waiting threads links to blocked threads.
* Include waiting and locked object lines to stacktraces too as I need to go to raw traces for that useful information otherwise.

Thanks in advance,