### PR TITLE
Waited lock info and implement ThreadsDependencyGraph for external plugin

### DIFF
--- a/core/src/com/sonyericsson/chkbugreport/BugReportModule.java
+++ b/core/src/com/sonyericsson/chkbugreport/BugReportModule.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2011 Sony Ericsson Mobile Communications AB
  * Copyright (C) 2012-2013 Sony Mobile Communications AB
+ * Copyright (C) 2016 Tuenti Technologies
  *
  * This file is part of ChkBugReport.
  *
@@ -684,11 +685,11 @@ public class BugReportModule extends Module {
     }
 
     public void addNodeToThreadsDependencyGraph(String name) {
-        this.threadsDependencyGraph.addNodeIfMissing(name);
+        this.threadsDependencyGraph.addThread(name);
     }
 
     public void addEdgeToThreadsDependencyGraph(String nameV, String nameW, String lockType) {
-        this.threadsDependencyGraph.addEdge(nameV, nameW, lockType);
+        this.threadsDependencyGraph.addThreadDependency(nameV, nameW, lockType);
     }
 
     public ThreadsDependencyGraph getThreadsDependencyGraph() {

--- a/core/src/com/sonyericsson/chkbugreport/BugReportModule.java
+++ b/core/src/com/sonyericsson/chkbugreport/BugReportModule.java
@@ -96,6 +96,8 @@ public class BugReportModule extends Module {
 
     private Vector<String> mBugReportHeader = new Vector<String>();
 
+    private ThreadsDependencyGraph threadsDependencyGraph;
+
     /**
      * Create an instance in order to process a bugreport.
      * @param context Contains various configs
@@ -677,6 +679,22 @@ public class BugReportModule extends Module {
         type.set(TYPE_BUGREPORT, 1); // low probability, so this will be used only as a fallback
     }
 
+    public void initThreadsDependencyGraph(int v) {
+       this.threadsDependencyGraph = new ThreadsDependencyGraph(v);
+    }
+
+    public void addNodeToThreadsDependencyGraph(String name) {
+        this.threadsDependencyGraph.addNodeIfMissing(name);
+    }
+
+    public void addEdgeToThreadsDependencyGraph(String nameV, String nameW, String lockType) {
+        this.threadsDependencyGraph.addEdge(nameV, nameW, lockType);
+    }
+
+    public ThreadsDependencyGraph getThreadsDependencyGraph() {
+        return threadsDependencyGraph;
+    }
+
     /* package */ static class SourceFile {
         String mName;
         String mType;
@@ -688,3 +706,5 @@ public class BugReportModule extends Module {
     }
 
 }
+
+

--- a/core/src/com/sonyericsson/chkbugreport/LabelEdge.java
+++ b/core/src/com/sonyericsson/chkbugreport/LabelEdge.java
@@ -3,13 +3,17 @@ package com.sonyericsson.chkbugreport;
 public class LabelEdge {
     private final int v;
     private final int w;
+    private final String nameV;
+    private final String nameW;
     private final String label;
 
-    public LabelEdge(int v, int w, String label) {
+    public LabelEdge(int v, int w, String nameV, String nameW, String label) {
         if (v < 0) throw new IndexOutOfBoundsException("Vertex names must be nonnegative integers");
         if (w < 0) throw new IndexOutOfBoundsException("Vertex names must be nonnegative integers");
         this.v = v;
         this.w = w;
+        this.nameV = nameV;
+        this.nameW = nameW;
         this.label = label;
     }
 
@@ -27,6 +31,14 @@ public class LabelEdge {
      */
     public int to() {
         return w;
+    }
+
+    public String fromName() {
+        return nameV;
+    }
+
+    public String toName() {
+        return nameW;
     }
 
     /**

--- a/core/src/com/sonyericsson/chkbugreport/LabelEdge.java
+++ b/core/src/com/sonyericsson/chkbugreport/LabelEdge.java
@@ -1,0 +1,48 @@
+package com.sonyericsson.chkbugreport;
+
+public class LabelEdge {
+    private final int v;
+    private final int w;
+    private final String label;
+
+    public LabelEdge(int v, int w, String label) {
+        if (v < 0) throw new IndexOutOfBoundsException("Vertex names must be nonnegative integers");
+        if (w < 0) throw new IndexOutOfBoundsException("Vertex names must be nonnegative integers");
+        this.v = v;
+        this.w = w;
+        this.label = label;
+    }
+
+    /**
+     * Returns the tail vertex of the directed edge.
+     * @return the tail vertex of the directed edge
+     */
+    public int from() {
+        return v;
+    }
+
+    /**
+     * Returns the head vertex of the directed edge.
+     * @return the head vertex of the directed edge
+     */
+    public int to() {
+        return w;
+    }
+
+    /**
+     * Returns the label of the directed edge.
+     * @return the label of the directed edge
+     */
+    public String label() {
+        return label;
+    }
+
+    /**
+     * Returns a string representation of the directed edge.
+     * @return a string representation of the directed edge
+     */
+    public String toString() {
+        return v + "->" + w + " " + label;
+    }
+
+}

--- a/core/src/com/sonyericsson/chkbugreport/LabeledEdge.java
+++ b/core/src/com/sonyericsson/chkbugreport/LabeledEdge.java
@@ -1,13 +1,13 @@
 package com.sonyericsson.chkbugreport;
 
-public class LabelEdge {
+public class LabeledEdge {
     private final int v;
     private final int w;
     private final String nameV;
     private final String nameW;
     private final String label;
 
-    public LabelEdge(int v, int w, String nameV, String nameW, String label) {
+    public LabeledEdge(int v, int w, String nameV, String nameW, String label) {
         if (v < 0) throw new IndexOutOfBoundsException("Vertex names must be nonnegative integers");
         if (w < 0) throw new IndexOutOfBoundsException("Vertex names must be nonnegative integers");
         this.v = v;

--- a/core/src/com/sonyericsson/chkbugreport/Module.java
+++ b/core/src/com/sonyericsson/chkbugreport/Module.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2011 Sony Ericsson Mobile Communications AB
  * Copyright (C) 2012-2013 Sony Mobile Communications AB
+ * Copyright (C) 2016 Tuenti Technologies
  *
  * This file is part of ChkBugReport.
  *
@@ -207,25 +208,37 @@ public abstract class Module implements ChapterParent {
     }
 
     private void loadExternalPlugins() {
-        File homeDir = new File(System.getProperty("user.home"));
-        File pluginDir = new File(homeDir, Util.PRIVATE_DIR_NAME);
-        if (pluginDir.exists() && pluginDir.isDirectory()) {
-            String files[] = pluginDir.list();
-            for (String fn : files) {
-                File f = new File(pluginDir, fn);
-                try {
-                    if (fn.endsWith(".jar")) {
-                        loadExternalJavaPlugin(f);
+
+        File[] pluginDirs = getPluginDirs();
+        for (int i = 0; i < pluginDirs.length; i++) {
+            File pluginDir = pluginDirs[i];
+            if (pluginDir.exists() && pluginDir.isDirectory()) {
+                String files[] = pluginDir.list();
+                for (String fn : files) {
+                    File f = new File(pluginDir, fn);
+                    try {
+                        if (fn.endsWith(".jar")) {
+                            loadExternalJavaPlugin(f);
+                        }
+                        if (fn.endsWith(".xml")) {
+                            loadExternalXmlPlugin(f);
+                        }
+                    } catch (Exception e) {
+                        System.err.println("Error loading external plugin: " + f.getAbsolutePath());
+                        e.printStackTrace();
                     }
-                    if (fn.endsWith(".xml")) {
-                        loadExternalXmlPlugin(f);
-                    }
-                } catch (Exception e) {
-                    System.err.println("Error loading external plugin: " + f.getAbsolutePath());
-                    e.printStackTrace();
                 }
             }
         }
+    }
+
+    private File[] getPluginDirs() {
+        File homeDir = new File(System.getProperty("user.home"));
+        File[] dirs = {
+                new File(homeDir, Util.PRIVATE_DIR_NAME),
+                new File(".", Util.EXTERNAL_PLUGINS_ALT_DIR_NAME)
+        };
+        return dirs;
     }
 
     private void loadExternalJavaPlugin(File jar) throws Exception {

--- a/core/src/com/sonyericsson/chkbugreport/ThreadsDependencyGraph.java
+++ b/core/src/com/sonyericsson/chkbugreport/ThreadsDependencyGraph.java
@@ -22,6 +22,8 @@ public class ThreadsDependencyGraph {
         digraph.addEdge(new LabelEdge(
                 threadsNodeIds.get(nameV),
                 threadsNodeIds.get(nameW),
+                nameV,
+                nameW,
                 lockType
         ));
     }
@@ -34,15 +36,20 @@ public class ThreadsDependencyGraph {
         return map;
     }
 
-    public Map<String, Integer> getNodes() {
-        return threadsNodeIds;
+    public Iterable<String> getNodes() {
+        return threadsNodeIds.keySet();
     }
 
-    public List<Integer> getDeadLock() {
-        List<Integer> list = new ArrayList<Integer>();
+    public List<String> getDeadLock() {
+        List<String> list = new ArrayList<String>();
         DirectedCycle directedCycle = new DirectedCycle(digraph);
         for (Integer node : directedCycle.cycle()) {
-            list.add(node);
+            for(String key : threadsNodeIds.keySet()) {
+                if (threadsNodeIds.get(key).equals(node)) {
+                    list.add(key);
+                    break;
+                }
+            }
         }
         return list;
     }

--- a/core/src/com/sonyericsson/chkbugreport/ThreadsDependencyGraph.java
+++ b/core/src/com/sonyericsson/chkbugreport/ThreadsDependencyGraph.java
@@ -49,18 +49,21 @@ public class ThreadsDependencyGraph {
      * @param lockType
      */
     public void addThreadDependency(String threadNameFrom, String threadNameTo, String lockType) {
-        digraph.addEdge(new LabeledEdge(
-                threadsNodeIds.get(threadNameFrom),
-                threadsNodeIds.get(threadNameTo),
-                threadNameFrom,
-                threadNameTo,
-                lockType
-        ));
+        try {
+            digraph.addEdge(new LabeledEdge(
+                    threadsNodeIds.get(threadNameFrom),
+                    threadsNodeIds.get(threadNameTo),
+                    threadNameFrom,
+                    threadNameTo,
+                    lockType
+            ));
+        } catch (IndexOutOfBoundsException e) {
+            e.printStackTrace();
+        }
     }
 
     /**
      * Gets a map of threadName to list of dependencies.
-     * @return
      */
     public Map<String, Iterable<LabeledEdge>> getThreadDependencyMap() {
         Map<String, Iterable<LabeledEdge>> map = new HashMap<String, Iterable<LabeledEdge>>();
@@ -70,18 +73,28 @@ public class ThreadsDependencyGraph {
         return map;
     }
 
+    /**
+     * Gets iterable of thread names.
+     */
     public Iterable<String> getThreadNames() {
         return threadsNodeIds.keySet();
     }
 
+    /**
+     * Gets a list of thread names involved in deadlock, empty if not existing.
+     */
     public List<String> getDeadLock() {
         List<String> list = new ArrayList<String>();
         DirectedCycle directedCycle = new DirectedCycle(digraph);
-        for (Integer node : directedCycle.cycle()) {
-            for(String key : threadsNodeIds.keySet()) {
-                if (threadsNodeIds.get(key).equals(node)) {
-                    list.add(key);
-                    break;
+        Iterable<Integer> cycle = directedCycle.cycle();
+
+        if (directedCycle.hasCycle()) {
+            for (Integer node : cycle) {
+                for (String key : threadsNodeIds.keySet()) {
+                    if (threadsNodeIds.get(key).equals(node)) {
+                        list.add(key);
+                        break;
+                    }
                 }
             }
         }

--- a/core/src/com/sonyericsson/chkbugreport/ThreadsDependencyGraph.java
+++ b/core/src/com/sonyericsson/chkbugreport/ThreadsDependencyGraph.java
@@ -1,0 +1,362 @@
+package com.sonyericsson.chkbugreport;
+
+import java.util.*;
+
+public class ThreadsDependencyGraph {
+    private final Digraph digraph;
+    private final Map<String, Integer> threadsNodeIds;
+
+
+    public ThreadsDependencyGraph(int v) {
+        digraph = new Digraph(v);
+        threadsNodeIds = new HashMap<String, Integer>();
+    }
+
+    public void addNodeIfMissing(String name) {
+        if (!threadsNodeIds.containsKey(name)) {
+            threadsNodeIds.put(name, threadsNodeIds.size());
+        }
+    }
+
+    public void addEdge(String nameV, String nameW, String lockType) {
+        digraph.addEdge(new LabelEdge(
+                threadsNodeIds.get(nameV),
+                threadsNodeIds.get(nameW),
+                lockType
+        ));
+    }
+
+    public Map<String, Iterable<LabelEdge>> getNodeAdjacencyListMap() {
+        Map<String, Iterable<LabelEdge>> map = new HashMap<String, Iterable<LabelEdge>>();
+        for (Map.Entry<String, Integer> entry : threadsNodeIds.entrySet()) {
+            map.put(entry.getKey(), digraph.adj(entry.getValue()));
+        }
+        return map;
+    }
+
+    public Map<String, Integer> getNodes() {
+        return threadsNodeIds;
+    }
+
+    public List<Integer> getDeadLock() {
+        List<Integer> list = new ArrayList<Integer>();
+        DirectedCycle directedCycle = new DirectedCycle(digraph);
+        for (Integer node : directedCycle.cycle()) {
+            list.add(node);
+        }
+        return list;
+    }
+
+    @Override
+    public String toString() {
+        return "{map=" + threadsNodeIds + ",digraph=" + digraph + "}";
+    }
+}
+
+
+
+
+/**
+ *  The <tt>Digraph</tt> class represents a directed graph of vertices
+ *  named 0 through <em>V</em> - 1.
+ *  It supports the following two primary operations: add an edge to the digraph,
+ *  iterate over all of the vertices adjacent from a given vertex.
+ *  Parallel edges and self-loops are permitted.
+ *  <p>
+ *  This implementation uses an adjacency-lists representation, which
+ *  is a vertex-indexed array of {@link Bag} objects.
+ *  All operations take constant time (in the worst case) except
+ *  iterating over the vertices adjacent from a given vertex, which takes
+ *  time proportional to the number of such vertices.
+ *  <p>
+ *  For additional documentation,
+ *  see <a href="http://algs4.cs.princeton.edu/42digraph">Section 4.2</a> of
+ *  <i>Algorithms, 4th Edition</i> by Robert Sedgewick and Kevin Wayne.
+ *
+ *  @author Robert Sedgewick
+ *  @author Kevin Wayne
+ */
+
+class Digraph {
+    private static final String NEWLINE = System.getProperty("line.separator");
+
+    private final int V;           // number of vertices in this digraph
+    private int E;                 // number of edges in this digraph
+    private Bag<LabelEdge>[] adj;    // adj[v] = adjacency list for vertex v
+    private int[] indegree;        // indegree[v] = indegree of vertex v
+
+    /**
+     * Initializes an empty digraph with <em>V</em> vertices.
+     *
+     * @param  V the number of vertices
+     * @throws IllegalArgumentException if V < 0
+     */
+    public Digraph(int V) {
+        if (V < 0) throw new IllegalArgumentException("Number of vertices in a Digraph must be nonnegative");
+        this.V = V;
+        this.E = 0;
+        indegree = new int[V];
+        adj = (Bag<LabelEdge>[]) new Bag[V];
+        for (int v = 0; v < V; v++) {
+            adj[v] = new Bag<LabelEdge>();
+        }
+    }
+
+    /**
+     * Returns the number of vertices in this digraph.
+     *
+     * @return the number of vertices in this digraph
+     */
+    public int V() {
+        return V;
+    }
+
+    /**
+     * Returns the number of edges in this digraph.
+     *
+     * @return the number of edges in this digraph
+     */
+    public int E() {
+        return E;
+    }
+
+
+    // throw an IndexOutOfBoundsException unless 0 <= v < V
+    private void validateVertex(int v) {
+        if (v < 0 || v >= V)
+            throw new IndexOutOfBoundsException("vertex " + v + " is not between 0 and " + (V-1));
+    }
+
+    /**
+     * Adds the directed edge v->w to this digraph.
+     *
+     * @throws IndexOutOfBoundsException unless both 0 <= v < V and 0 <= w < V
+     */
+    public void addEdge(LabelEdge labelEdge) {
+        validateVertex(labelEdge.from());
+        validateVertex(labelEdge.to());
+        adj[labelEdge.from()].add(labelEdge);
+        indegree[labelEdge.to()]++;
+        E++;
+    }
+
+    /**
+     * Returns the vertices adjacent from vertex <tt>v</tt> in this digraph.
+     *
+     * @param  v the vertex
+     * @return the vertices adjacent from vertex <tt>v</tt> in this digraph, as an iterable
+     * @throws IndexOutOfBoundsException unless 0 <= v < V
+     */
+    public Iterable<LabelEdge> adj(int v) {
+        validateVertex(v);
+        return adj[v];
+    }
+
+    /**
+     * Returns the number of directed edges incident from vertex <tt>v</tt>.
+     * This is known as the <em>outdegree</em> of vertex <tt>v</tt>.
+     *
+     * @param  v the vertex
+     * @return the outdegree of vertex <tt>v</tt>
+     * @throws IndexOutOfBoundsException unless 0 <= v < V
+     */
+    public int outdegree(int v) {
+        validateVertex(v);
+        return adj[v].size();
+    }
+
+    /**
+     * Returns a string representation of the graph.
+     *
+     * @return the number of vertices <em>V</em>, followed by the number of edges <em>E</em>,
+     *         followed by the <em>V</em> adjacency lists
+     */
+    public String toString() {
+        StringBuilder s = new StringBuilder();
+        s.append(V + " vertices, " + E + " edges " + NEWLINE);
+        for (int v = 0; v < V; v++) {
+            s.append(String.format("%d: ", v));
+            for (LabelEdge l : adj[v]) {
+                s.append(String.format("%d ", l.to()));
+                s.append(" - " + l.label());
+            }
+            s.append(NEWLINE);
+        }
+        return s.toString();
+    }
+
+}
+
+
+
+class Bag<Item> implements Iterable<Item> {
+    private Node<Item> first;    // beginning of bag
+    private int N;               // number of elements in bag
+
+    // helper linked list class
+    private static class Node<Item> {
+        private Item item;
+        private Node<Item> next;
+    }
+
+    /**
+     * Initializes an empty bag.
+     */
+    public Bag() {
+        first = null;
+        N = 0;
+    }
+
+    /**
+     * Returns true if this bag is empty.
+     *
+     * @return <tt>true</tt> if this bag is empty;
+     * <tt>false</tt> otherwise
+     */
+    public boolean isEmpty() {
+        return first == null;
+    }
+
+    /**
+     * Returns the number of items in this bag.
+     *
+     * @return the number of items in this bag
+     */
+    public int size() {
+        return N;
+    }
+
+    /**
+     * Adds the item to this bag.
+     *
+     * @param item the item to add to this bag
+     */
+    public void add(Item item) {
+        Node<Item> oldfirst = first;
+        first = new Node<Item>();
+        first.item = item;
+        first.next = oldfirst;
+        N++;
+    }
+
+    /**
+     * Returns an iterator that iterates over the items in this bag in arbitrary order.
+     *
+     * @return an iterator that iterates over the items in this bag in arbitrary order
+     */
+    public Iterator<Item> iterator() {
+        return new ListIterator<Item>(first);
+    }
+
+    // an iterator, doesn't implement remove() since it's optional
+    private class ListIterator<Item> implements Iterator<Item> {
+        private Node<Item> current;
+
+        public ListIterator(Node<Item> first) {
+            current = first;
+        }
+
+        public boolean hasNext() {
+            return current != null;
+        }
+
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        public Item next() {
+            if (!hasNext()) throw new NoSuchElementException();
+            Item item = current.item;
+            current = current.next;
+            return item;
+        }
+    }
+}
+
+class DirectedCycle {
+    private boolean[] marked;        // marked[v] = has vertex v been marked?
+    private int[] edgeTo;            // edgeTo[v] = previous vertex on path to v
+    private boolean[] onStack;       // onStack[v] = is vertex on the stack?
+    private Stack<Integer> cycle;    // directed cycle (or null if no such cycle)
+
+    /**
+     * Determines whether the digraph <tt>G</tt> has a directed cycle and, if so,
+     * finds such a cycle.
+     * @param G the digraph
+     */
+    public DirectedCycle(Digraph G) {
+        marked  = new boolean[G.V()];
+        onStack = new boolean[G.V()];
+        edgeTo  = new int[G.V()];
+        for (int v = 0; v < G.V(); v++)
+            if (!marked[v] && cycle == null) dfs(G, v);
+    }
+
+    // check that algorithm computes either the topological order or finds a directed cycle
+    private void dfs(Digraph G, int v) {
+        onStack[v] = true;
+        marked[v] = true;
+        for (LabelEdge labelEdge : G.adj(v)) {
+
+            // short circuit if directed cycle found
+            if (cycle != null) return;
+
+                //found new vertex, so recur
+            else if (!marked[labelEdge.to()]) {
+                edgeTo[labelEdge.to()] = v;
+                dfs(G, labelEdge.to());
+            }
+
+            // trace back directed cycle
+            else if (onStack[labelEdge.to()]) {
+                cycle = new Stack<Integer>();
+                for (int x = v; x != labelEdge.to(); x = edgeTo[x]) {
+                    cycle.push(x);
+                }
+                cycle.push(labelEdge.to());
+                cycle.push(v);
+                assert check();
+            }
+        }
+        onStack[v] = false;
+    }
+
+    /**
+     * Does the digraph have a directed cycle?
+     * @return <tt>true</tt> if the digraph has a directed cycle, <tt>false</tt> otherwise
+     */
+    public boolean hasCycle() {
+        return cycle != null;
+    }
+
+    /**
+     * Returns a directed cycle if the digraph has a directed cycle, and <tt>null</tt> otherwise.
+     * @return a directed cycle (as an iterable) if the digraph has a directed cycle,
+     *    and <tt>null</tt> otherwise
+     */
+    public Iterable<Integer> cycle() {
+        return cycle;
+    }
+
+
+    // certify that digraph has a directed cycle if it reports one
+    private boolean check() {
+
+        if (hasCycle()) {
+            // verify cycle
+            int first = -1, last = -1;
+            for (int v : cycle()) {
+                if (first == -1) first = v;
+                last = v;
+            }
+            if (first != last) {
+                System.err.printf("cycle begins with %d and ends with %d\n", first, last);
+                return false;
+            }
+        }
+
+
+        return true;
+    }
+
+}

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Analyzer.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Analyzer.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2011 Sony Ericsson Mobile Communications AB
  * Copyright (C) 2012 Sony Mobile Communications AB
+ * Copyright (C) 2016 Tuenti Technologies
  *
  * This file is part of ChkBugReport.
  *

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Analyzer.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Analyzer.java
@@ -277,6 +277,7 @@ import java.util.Vector;
                 procNames.append(procList.get(j).getName());
             }
 
+            br.initThreadsDependencyGraph(deadlock.size() + blocked.size());
             Bug bug = new Bug(Bug.Type.PHONE_ERR, Bug.PRIO_DEADLOCK, 0, "Deadlock in process(es) " + procNames);
             DocNode msg = new Block(bug).addStyle("bug");
             new Para(msg)
@@ -302,12 +303,18 @@ import java.util.Vector;
             li.add(new ProcessLink(br, p.getPid()));
             li.add(" / ");
             li.add(new Link(stack.getAnchor(), stack.getName()));
+            br.addNodeToThreadsDependencyGraph(stack.getName());
             StackTrace.WaitInfo stackWaitOn = stack.getWaitOn();
             if (stackWaitOn != null && referenceList != null) {
                 for (StackTrace s : referenceList) {
                     if (s.getTid() == stackWaitOn.getThreadId()) {
                         li.add("  waiting: ");
                         li.add(new Link(s.getAnchor(), s.getName()));
+                        br.addNodeToThreadsDependencyGraph(s.getName());
+                        br.addEdgeToThreadsDependencyGraph(
+                                stack.getName(),
+                                s.getName(),
+                                stackWaitOn.getLockType());
                         if (s.getWaitOn().getLockId() != null && s.getWaitOn().getLockType() != null) {
                             li.add(" for " + stackWaitOn.getLockType());
                         }
@@ -319,3 +326,4 @@ import java.util.Vector;
     }
 
 }
+

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Generator.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Generator.java
@@ -102,7 +102,7 @@ import java.util.regex.Pattern;
                 if (waitOn != null) {
                     StackTrace stackWaitOn = p.findTid(waitOn.getThreadId());
                     waiting.add(" waiting on ");
-                    waiting.add(new Link(stackWaitOn.getAnchor(), "thread-" + waitOn));
+                    waiting.add(new Link(stackWaitOn.getAnchor(), "thread-" + waitOn.getThreadId()));
                 } else if (aidlDep != null) {
                     Process aidlDepProc = aidlDep.getProcess();
                     waiting.add(" waiting on ");

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Generator.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Generator.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2011 Sony Ericsson Mobile Communications AB
  * Copyright (C) 2012 Sony Mobile Communications AB
+ * Copyright (C) 2016 Tuenti Technologies
  *
  * This file is part of ChkBugReport.
  *

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Generator.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Generator.java
@@ -96,10 +96,11 @@ import java.util.regex.Pattern;
                 StackTrace stack = p.get(i);
                 Anchor anchorTrace = stack.getAnchor();
                 DocNode waiting = new DocNode();
-                int waitOn = stack.getWaitOn();
+                StackTrace.WaitInfo waitOn = stack.getWaitOn();
+
                 StackTrace aidlDep = stack.getAidlDependency();
-                if (waitOn >= 0) {
-                    StackTrace stackWaitOn = p.findTid(waitOn);
+                if (waitOn != null) {
+                    StackTrace stackWaitOn = p.findTid(waitOn.getThreadId());
                     waiting.add(" waiting on ");
                     waiting.add(new Link(stackWaitOn.getAnchor(), "thread-" + waitOn));
                 } else if (aidlDep != null) {

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTrace.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTrace.java
@@ -32,12 +32,36 @@ import java.util.Vector;
     private int mTid;
     private int mPrio;
     private String mState;
-    private int mWaitOn;
+    private WaitInfo waitInfo;
     private WeakReference<Process> mProc;
     private Vector<String> mProps = new Vector<String>();
     private int mPid;
     private StackTrace mAidlDep;
     private Anchor mAnchor;
+
+    static class WaitInfo {
+        private final int threadId;
+        private final String lockId;
+        private final String lockType;
+
+        public WaitInfo(int threadId, String lockId, String lockType) {
+            this.threadId = threadId;
+            this.lockId = lockId;
+            this.lockType = lockType;
+        }
+
+        public int getThreadId() {
+            return threadId;
+        }
+
+        public String getLockId() {
+            return lockId;
+        }
+
+        public String getLockType() {
+            return lockType;
+        }
+    }
 
     public StackTrace(Process process, String name, int tid, int prio, String threadState) {
         mProc = new WeakReference<Process>(process);
@@ -45,7 +69,6 @@ import java.util.Vector;
         mTid = tid;
         mPrio = prio;
         mState = threadState;
-        mWaitOn = -1;
     }
 
     public void parseProperties(String s) {
@@ -133,12 +156,12 @@ import java.util.Vector;
         return mPrio;
     }
 
-    public int getWaitOn() {
-        return mWaitOn;
+    public WaitInfo getWaitOn() {
+        return waitInfo;
     }
 
-    public void setWaitOn(int tid) {
-        mWaitOn = tid;
+    public void setWaitOn(WaitInfo waitInfo) {
+        this.waitInfo = waitInfo;
     }
 
     public String getState() {
@@ -166,8 +189,8 @@ import java.util.Vector;
     }
 
     public StackTrace getDependency() {
-        if (mWaitOn >= 0) {
-            return getProcess().findTid(mWaitOn);
+        if (waitInfo != null) {
+            return getProcess().findTid(waitInfo.getThreadId());
         }
         return mAidlDep;
     }

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2011 Sony Ericsson Mobile Communications AB
  * Copyright (C) 2012 Sony Mobile Communications AB
+ * Copyright (C) 2016 Tuenti Technologies
  *
  * This file is part of ChkBugReport.
  *

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -182,7 +182,9 @@ import java.util.regex.Pattern;
             if (idx2 > 0) {
                 int tid = Integer.parseInt(buff.substring(idx, idx2));
                 if (tid != curStackTrace.getTid()) {
-                    curStackTrace.setWaitOn(tid);
+                    String lockId = buff.substring(buff.indexOf("<") + 1, buff.indexOf(">"));
+                    String lockType = buff.substring(buff.indexOf("(") + 1, buff.indexOf(")"));
+                    curStackTrace.setWaitOn(new StackTrace.WaitInfo(tid, lockId, lockType));
                 }
             }
         }

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -120,28 +120,7 @@ import java.util.regex.Pattern;
                         StackTraceItem item = new StackTraceItem("", buff, 0);
                         curStackTrace.addStackTraceItem(item);
                         if (buff.startsWith("waiting ")) {
-                            int idx = -1;
-                            String needle = "";
-                            for (String possibleNeedle : getPossibleWaitingNeedles()) {
-                                idx = buff.indexOf(possibleNeedle);
-                                if (idx > 0) {
-                                    needle = possibleNeedle;
-                                    break;
-                                }
-                            }
-                            if (idx > 0) {
-                                idx += needle.length();
-                                int idx2 = buff.indexOf(' ', idx);
-                                if (idx2 < 0) {
-                                    idx2 = buff.length();
-                                }
-                                if (idx2 > 0) {
-                                    int tid = Integer.parseInt(buff.substring(idx, idx2));
-                                    if (tid != curStackTrace.getTid()) {
-                                        curStackTrace.setWaitOn(tid);
-                                    }
-                                }
-                            }
+                            processWaitingToLockLine(curStackTrace, buff);
                         }
                     } else if (buff.startsWith("  at ")) {
                         int idx0 = buff.indexOf('(');
@@ -182,6 +161,31 @@ import java.util.regex.Pattern;
 
         }
         return processes;
+    }
+
+    private void processWaitingToLockLine(StackTrace curStackTrace, String buff) {
+        int idx = -1;
+        String needle = "";
+        for (String possibleNeedle : getPossibleWaitingNeedles()) {
+            idx = buff.indexOf(possibleNeedle);
+            if (idx > 0) {
+                needle = possibleNeedle;
+                break;
+            }
+        }
+        if (idx > 0) {
+            idx += needle.length();
+            int idx2 = buff.indexOf(' ', idx);
+            if (idx2 < 0) {
+                idx2 = buff.length();
+            }
+            if (idx2 > 0) {
+                int tid = Integer.parseInt(buff.substring(idx, idx2));
+                if (tid != curStackTrace.getTid()) {
+                    curStackTrace.setWaitOn(tid);
+                }
+            }
+        }
     }
 
     private Iterable<String> getPossibleWaitingNeedles() {

--- a/core/src/com/sonyericsson/chkbugreport/util/Util.java
+++ b/core/src/com/sonyericsson/chkbugreport/util/Util.java
@@ -45,6 +45,7 @@ public final class Util {
      * This is relative to the user's home directory.
      */
     public static final String PRIVATE_DIR_NAME = ".chkbugreport";
+    public static final String EXTERNAL_PLUGINS_ALT_DIR_NAME = "extplugins";
 
     /** Length of 1 second in milliseconds */
     public static final long SEC_MS = 1000;


### PR DESCRIPTION
- Add info about waited lock object in generator.
- Introduce ThreadsDependencyGraph to be used by external plugin.
- Search for external plugins not just in .chkbugreport but in relative extplugins dir too so that it can be distributed as system wide tool easier.