### PR TITLE
Fix parse for lines like ' at com.google.android.g.f.run(:com.google.android.gms:85)'

### DIFF
--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -136,11 +136,9 @@ import java.util.regex.Pattern;
                                 String lineS = buff.substring(idx1 + 1, idx2);
                                 if (lineS.startsWith("~")) {
                                     lineS = lineS.substring(1);
-                                } else if (lineS.indexOf(':') > 0) {
-                                    String[] parts = lineS.split(":");
-                                    if (parts.length > 0) {
-                                        lineS = parts[1];
-                                    }
+                                } else if(lineS.lastIndexOf(':') > 0) {
+                                     int position = lineS.lastIndexOf(':');
+                                     lineS = lineS.substring(position+1);
                                 }
                                 line = Integer.parseInt(lineS);
                             }

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -136,6 +136,11 @@ import java.util.regex.Pattern;
                                 String lineS = buff.substring(idx1 + 1, idx2);
                                 if (lineS.startsWith("~")) {
                                     lineS = lineS.substring(1);
+                                } else if (lineS.indexOf(':') > 0) {
+                                    String[] parts = lineS.split(":");
+                                    if (parts.length > 0) {
+                                        lineS = parts[1];
+                                    }
                                 }
                                 line = Integer.parseInt(lineS);
                             }

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -136,9 +136,9 @@ import java.util.regex.Pattern;
                                 String lineS = buff.substring(idx1 + 1, idx2);
                                 if (lineS.startsWith("~")) {
                                     lineS = lineS.substring(1);
-                                } else if(lineS.lastIndexOf(':') > 0) {
-                                     int position = lineS.lastIndexOf(':');
-                                     lineS = lineS.substring(position+1);
+                                } else if (lineS.lastIndexOf(':') > 0) {
+                                    int position = lineS.lastIndexOf(':');
+                                    lineS = lineS.substring(position+1);
                                 }
                                 line = Integer.parseInt(lineS);
                             }


### PR DESCRIPTION
Parsing a stacktrace containing lines like
`
at com.google.android.g.f.run(:com.google.android.gms:85)`
Causes 

```
java.lang.NumberFormatException: For input string: "com.google.android.gms:85"
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
    at java.lang.Integer.parseInt(Integer.java:492)
    at java.lang.Integer.parseInt(Integer.java:527)
    at com.sonyericsson.chkbugreport.plugins.stacktrace.StackTraceScanner.scan(StackTraceScanner.java:140)
    at com.sonyericsson.chkbugreport.plugins.stacktrace.StackTracePlugin.run(StackTracePlugin.java:129)
    at com.sonyericsson.chkbugreport.plugins.stacktrace.StackTracePlugin.run(StackTracePlugin.java:123)
    at com.sonyericsson.chkbugreport.plugins.stacktrace.StackTracePlugin.load(StackTracePlugin.java:86)
    at com.sonyericsson.chkbugreport.Module.runPlugins(Module.java:662)
    at com.sonyericsson.chkbugreport.Module.generate(Module.java:567)
    at com.sonyericsson.chkbugreport.Main.run(Main.java:232)
    at com.sonyericsson.chkbugreport.Main.main(Main.java:358)
```

_Sorry for the previous pull request and possible inconveniences_
