### PR TITLE
Use new name for meminfo dump

### DIFF
--- a/core/src/com/sonyericsson/chkbugreport/Section.java
+++ b/core/src/com/sonyericsson/chkbugreport/Section.java
@@ -31,7 +31,7 @@ public class Section extends Lines {
     public static final String DUMP_OF_SERVICE_ALARM = "DUMP OF SERVICE alarm";
     public static final String DUMP_OF_SERVICE_BATTERYINFO = "DUMP OF SERVICE batteryinfo";
     public static final String DUMP_OF_SERVICE_BATTERYSTATS = "DUMP OF SERVICE batterystats";
-    public static final String DUMP_OF_SERVICE_MEMINFO = "DUMP OF SERVICE meminfo";
+    public static final String DUMP_OF_SERVICE_MEMINFO = "DUMP OF SERVICE HIGH meminfo";
     public static final String DUMP_OF_SERVICE_PACKAGE = "DUMP OF SERVICE package";
     public static final String DUMP_OF_SERVICE_SURFACEFLINGER = "DUMP OF SERVICE SurfaceFlinger";
     public static final String DUMP_OF_SERVICE_WINDOW = "DUMP OF SERVICE window";


### PR DESCRIPTION
Meminfo has a different header now:

```
DUMP OF SERVICE HIGH meminfo:
Applications Memory Usage (in Kilobytes):
Uptime: 5131557 Realtime: 9414283
```

This simply picks up the new header which has the `HIGH` added to it.

Tested locally.