### PR TITLE
Stelau/stacktrace parse

### DIFF
--- a/core/res/style.css
+++ b/core/res/style.css
@@ -518,6 +518,11 @@ table.auto-width {
     color: #f00;
 }
 
+.stacktrace-unparsable {
+    color: #888;
+    font-style: italic;
+}
+
 /**************************************************************
  * Main thread activity
  **************************************************************/

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Generator.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Generator.java
@@ -153,6 +153,9 @@ import java.util.regex.Pattern;
                     if (item.getFileName() != null) {
                         new Span(stItem).addStyle("stacktrace-item-file").add(" (" + item.getFileName() + ")");
                     }
+                    if (item.getOffset() != -1) {
+                        new Span(stItem).addStyle("stacktrace-item-offset").add(String.format(" (offset %08x)", item.getOffset()));
+                    }
                 }
             }
 

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Generator.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Generator.java
@@ -130,7 +130,7 @@ import java.util.regex.Pattern;
                 for (int j = 0; j < itemCnt; j++) {
                     StackTraceItem item = stack.get(j);
                     HtmlNode stItem = new Block(stItems).addStyle("stacktrace-item");
-                    if(item.getRaw() != null && item.getType() == StackTraceItem.TYPE_JAVA) {
+                    if(item.getRaw() != null && item.getType() == StackTraceItem.Type.JAVA) {
                         stItem.addStyle("stacktrace-item-java");
                         new Span(stItem)
                             .addStyle(item.getStyle())
@@ -138,7 +138,7 @@ import java.util.regex.Pattern;
                             .add(item.getRaw());
                         continue;
                     }
-                    if (item.getType() == StackTraceItem.TYPE_JAVA) {
+                    if (item.getType() == StackTraceItem.Type.JAVA) {
                         stItem.addStyle("stacktrace-item-java");
                         new Span(stItem)
                             .addStyle("stacktrace-item-method")
@@ -246,7 +246,7 @@ import java.util.regex.Pattern;
             if (method == null) {
                 continue;
             }
-            if (item.getType() == StackTraceItem.TYPE_JAVA) {
+            if (item.getType() == StackTraceItem.Type.JAVA) {
                 Matcher m = p.matcher(method);
                 if (m.find()) {
                     String interf = m.group(1);
@@ -262,7 +262,7 @@ import java.util.regex.Pattern;
             if (method == null) {
                 continue;
             }
-            if (item.getType() == StackTraceItem.TYPE_NATIVE) {
+            if (item.getType() == StackTraceItem.Type.NATIVE) {
                 Matcher m = p1.matcher(method);
                 if (prevNativeMethod != null && m.find()) {
                     String stub = m.group(1);

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Generator.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Generator.java
@@ -130,6 +130,14 @@ import java.util.regex.Pattern;
                 for (int j = 0; j < itemCnt; j++) {
                     StackTraceItem item = stack.get(j);
                     HtmlNode stItem = new Block(stItems).addStyle("stacktrace-item");
+                    if(item.getRaw() != null && item.getType() == StackTraceItem.TYPE_JAVA) {
+                        stItem.addStyle("stacktrace-item-java");
+                        new Span(stItem)
+                            .addStyle(item.getStyle())
+                            .setTitle("Raw unparsed stacktrace line")
+                            .add(item.getRaw());
+                        continue;
+                    }
                     if (item.getType() == StackTraceItem.TYPE_JAVA) {
                         stItem.addStyle("stacktrace-item-java");
                         new Span(stItem)

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Process.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Process.java
@@ -27,7 +27,8 @@ import java.lang.ref.WeakReference;
 import java.util.Iterator;
 import java.util.Vector;
 
-/* package */ final class Process implements Iterable<StackTrace> {
+/* package */
+public final class Process implements Iterable<StackTrace> {
 
     private int mPid;
     private String mName;

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Processes.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/Processes.java
@@ -24,7 +24,8 @@ import com.sonyericsson.chkbugreport.doc.Chapter;
 
 import java.util.Vector;
 
-/* package */ final class Processes extends Vector<Process> {
+/* package */
+public final class Processes extends Vector<Process> {
 
     private int mId;
     private String mName;

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTrace.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTrace.java
@@ -130,7 +130,7 @@ public final class StackTrace implements Iterable<StackTraceItem> {
     public boolean isFirstJavaItem(int idx) {
         int cnt = Math.min(getCount(), idx);
         for (int i = 0; i < cnt; i++) {
-            if (get(i).getType() == StackTraceItem.TYPE_JAVA) {
+            if (get(i).getType() == StackTraceItem.Type.JAVA) {
                 return false;
             }
         }

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTrace.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTrace.java
@@ -25,7 +25,8 @@ import java.lang.ref.WeakReference;
 import java.util.Iterator;
 import java.util.Vector;
 
-/* package */ final class StackTrace implements Iterable<StackTraceItem> {
+/* package */
+public final class StackTrace implements Iterable<StackTraceItem> {
 
     private String mName;
     private Vector<StackTraceItem> mStack = new Vector<StackTraceItem>();

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceItem.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceItem.java
@@ -34,6 +34,8 @@ public final class StackTraceItem {
     private String mMethod;
     /** Address offset from beginning of method, for native stack traces */
     private int mMethodOffset;
+    /** Offset in shared lib when method unknown) **/
+    private long mOffset;
     /** The name of the file, if known */
     private String mFileName;
     /** The line number inside the file, if known */
@@ -56,6 +58,7 @@ public final class StackTraceItem {
         mFileName = (fileName == null) ? null : fileName.intern();
         mLine = line;
         mPC = -1; // unknown;
+        mOffset = -1; //unknown;
     }
 
     /**
@@ -70,6 +73,23 @@ public final class StackTraceItem {
         mMethodOffset = methodOffset;
         mFileName = (fileName == null) ? null : fileName.intern();
         mLine = -1; // unknown
+        mOffset = -1; //unknown
+        mPC = pc;
+    }
+
+    /**
+     * Create a native stack trace item
+     * @param pc The pc Address
+     * @param fileName The file name
+     * @param offset The offset in the shared library
+     */
+    public StackTraceItem(long pc, String fileName, long offset) {
+        mType = TYPE_NATIVE;
+        mMethod = null;
+        mMethodOffset = -1;
+        mFileName = (fileName == null) ? null : fileName.intern();
+        mLine = -1;
+        mOffset = offset;
         mPC = pc;
     }
 
@@ -91,6 +111,10 @@ public final class StackTraceItem {
 
     public int getMethodOffset() {
         return mMethodOffset;
+    }
+
+    public long getOffset() {
+        return mOffset;
     }
 
     public long getPC() {

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceItem.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceItem.java
@@ -19,7 +19,8 @@
  */
 package com.sonyericsson.chkbugreport.plugins.stacktrace;
 
-/* package */ final class StackTraceItem {
+/* package */
+public final class StackTraceItem {
 
     public static final int TYPE_JAVA = 0;
     public static final int TYPE_NATIVE = 1;

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceItem.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceItem.java
@@ -27,7 +27,9 @@ public final class StackTraceItem {
 
     public static final String STYLE_ERR = "stacktrace-err";
     public static final String STYLE_BUSY = "stacktrace-busy";
-
+    public static final String STYLE_UNPARSABLE = "stacktrace-unparsable";
+    /** The raw line if parser failed**/
+    private String mRaw;
     /** The type of the stack traces: java or native */
     private int mType;
     /** Method/function name, if known (for native stack it might be unknown) */
@@ -44,6 +46,26 @@ public final class StackTraceItem {
     private long mPC; // long, because soon we could have 64bit addresses
     /** The css style to use for the item */
     private String mStyle = "";
+
+
+    /**
+     * Create a java stack trace item
+     * @param raw The raw stack trace line (line was not able to be parsed)
+     * @param type The type of trace line (TYPE_JAVA or TYPE_NATIVE)
+     */
+    public StackTraceItem(String raw, int type) {
+        mRaw = raw;
+        mType = TYPE_JAVA;
+        mStyle = STYLE_UNPARSABLE;
+
+        //All Unknown:
+        mMethod = null;
+        mMethodOffset = -1;
+        mFileName = null;
+        mLine = -1;
+        mPC = -1;
+        mOffset = -1;
+    }
 
     /**
      * Create a java stack trace item
@@ -128,5 +150,7 @@ public final class StackTraceItem {
     public int getLine() {
         return mLine;
     }
-
+    public String getRaw() {
+        return mRaw;
+    }
 }

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceItem.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceItem.java
@@ -22,8 +22,10 @@ package com.sonyericsson.chkbugreport.plugins.stacktrace;
 /* package */
 public final class StackTraceItem {
 
-    public static final int TYPE_JAVA = 0;
-    public static final int TYPE_NATIVE = 1;
+    public enum Type {
+        JAVA,
+        NATIVE
+    }
 
     public static final String STYLE_ERR = "stacktrace-err";
     public static final String STYLE_BUSY = "stacktrace-busy";
@@ -31,7 +33,7 @@ public final class StackTraceItem {
     /** The raw line if parser failed**/
     private String mRaw;
     /** The type of the stack traces: java or native */
-    private int mType;
+    private Type mType;
     /** Method/function name, if known (for native stack it might be unknown) */
     private String mMethod;
     /** Address offset from beginning of method, for native stack traces */
@@ -53,9 +55,9 @@ public final class StackTraceItem {
      * @param raw The raw stack trace line (line was not able to be parsed)
      * @param type The type of trace line (TYPE_JAVA or TYPE_NATIVE)
      */
-    public StackTraceItem(String raw, int type) {
+    public StackTraceItem(String raw, Type type) {
         mRaw = raw;
-        mType = TYPE_JAVA;
+        mType = Type.JAVA;
         mStyle = STYLE_UNPARSABLE;
 
         //All Unknown:
@@ -74,7 +76,7 @@ public final class StackTraceItem {
      * @param line The line number
      */
     public StackTraceItem(String method, String fileName, int line) {
-        mType = TYPE_JAVA;
+        mType = Type.JAVA;
         mMethod = (method == null) ? null : method.intern();
         mMethodOffset = -1; // unknown
         mFileName = (fileName == null) ? null : fileName.intern();
@@ -90,7 +92,7 @@ public final class StackTraceItem {
      * @param line The line number
      */
     public StackTraceItem(long pc, String fileName, String method, int methodOffset) {
-        mType = TYPE_NATIVE;
+        mType = Type.NATIVE;
         mMethod = (method == null) ? null : method.intern();
         mMethodOffset = methodOffset;
         mFileName = (fileName == null) ? null : fileName.intern();
@@ -106,7 +108,7 @@ public final class StackTraceItem {
      * @param offset The offset in the shared library
      */
     public StackTraceItem(long pc, String fileName, long offset) {
-        mType = TYPE_NATIVE;
+        mType = Type.NATIVE;
         mMethod = null;
         mMethodOffset = -1;
         mFileName = (fileName == null) ? null : fileName.intern();
@@ -115,7 +117,7 @@ public final class StackTraceItem {
         mPC = pc;
     }
 
-    public int getType() {
+    public Type getType() {
         return mType;
     }
 

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -140,7 +140,11 @@ import java.util.regex.Pattern;
                                     int position = lineS.lastIndexOf(':');
                                     lineS = lineS.substring(position+1);
                                 }
-                                line = Integer.parseInt(lineS);
+                                try {
+                                  line = Integer.parseInt(lineS);
+                                } catch(NumberFormatException e) {
+                                  br.printErr(4, "Skipping parsing for misformed line number: " + lineS);
+                                }
                             }
                             StackTraceItem item = new StackTraceItem(method, fileName, line);
                             curStackTrace.addStackTraceItem(item);

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -31,7 +31,9 @@ import java.util.regex.Pattern;
 /**
  * This class is responsible to scan the stack trace output and collect the data
  */
-/* package */ final class StackTraceScanner {
+/* package */
+
+public final class StackTraceScanner {
 
     private static final int STATE_INIT  = 0;
     private static final int STATE_PROC  = 1;
@@ -42,8 +44,8 @@ import java.util.regex.Pattern;
     }
 
     public Processes scan(BugReportModule br, int id, Section sec, String chapterName) {
-        Pattern pNat = Pattern.compile("\\s+#\\d+\\s+pc\\s+([\\da-f]+)\\s+([^() ]+)\\s+(?:\\((.*)\\+(\\d+)\\))?\\s?+\\(BuildId:\\s(.*)\\)");
-        Pattern pNatAlt = Pattern.compile("\\s+#..  pc (........)  ([^() ]+) \\(deleted\\)");
+        Pattern pNat = Pattern.compile("\\s+#\\d+\\s+pc\\s+([\\da-f]+)\\s+([^() ]+)\\s+(?:\\((.*)\\+(\\d+)\\))?\\s?+(?:\\(BuildId:\\s(.*)\\))?");
+        Pattern pNatAlt = Pattern.compile("\\s+#\\d+\\s+pc\\s+([\\da-f]+)\\s+<(.*)>");
         int cnt = sec.getLineCount();
         int state = STATE_INIT;
         Processes processes = new Processes(br, id, chapterName, sec.getName());
@@ -149,7 +151,11 @@ import java.util.regex.Pattern;
                             StackTraceItem item = new StackTraceItem(method, fileName, line);
                             curStackTrace.addStackTraceItem(item);
                         }
-                    } else if (buff.trim().startsWith("#")) {
+                    } else if (buff.trim().startsWith("#") || buff.trim().startsWith("native: #")) {
+                        //Trim off Native:
+                        if(buff.trim().startsWith("native")) {
+                            buff = buff.substring(buff.indexOf(" #"));
+                        }
                         Matcher m = pNat.matcher(buff);
                         if (!m.matches()) {
                             m = pNatAlt.matcher(buff);

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.sonyericsson.chkbugreport.plugins.stacktrace.StackTraceItem.TYPE_JAVA;
+
 /**
  * This class is responsible to scan the stack trace output and collect the data
  */
@@ -143,12 +145,15 @@ public final class StackTraceScanner {
                                     lineS = lineS.substring(position+1);
                                 }
                                 try {
-                                  line = Integer.parseInt(lineS);
+                                    line = Integer.parseInt(lineS);
                                 } catch(NumberFormatException e) {
-                                  br.printErr(4, "Skipping parsing for misformed line number: " + lineS);
+                                    br.printErr(4, "Inserting raw line for unparsable: " + buff);
                                 }
                             }
-                            StackTraceItem item = new StackTraceItem(method, fileName, line);
+                            StackTraceItem item = (fileName != null && line != -1)
+                                ? new StackTraceItem(method, fileName, line)
+                                : new StackTraceItem(buff.substring(buff.indexOf("at ") + 3), TYPE_JAVA);
+
                             curStackTrace.addStackTraceItem(item);
                         }
                     } else if (buff.trim().startsWith("#") || buff.trim().startsWith("native: #")) {

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -44,7 +44,7 @@ public final class StackTraceScanner {
     }
 
     public Processes scan(BugReportModule br, int id, Section sec, String chapterName) {
-        Pattern pNat = Pattern.compile("\\s+#\\d+\\s+pc\\s+([\\da-f]+)\\s+([^() ]+)\\s+(?:\\((.*)\\+(\\d+)\\))?\\s?+(?:\\(BuildId:\\s(.*)\\))?");
+        Pattern pNat = Pattern.compile("\\s+#\\d+\\s+pc\\s+([\\da-f]+)\\s+([^() ]+)\\s+(?:\\((.*)\\+(\\d+)\\))?\\s?+(?:\\(BuildId:\\s(.*)\\))?\\s?+(?:\\(offset ([\\da-f]+)\\)\\s+\\(\\?\\?\\?\\))?");
         Pattern pNatAlt = Pattern.compile("\\s+#\\d+\\s+pc\\s+([\\da-f]+)\\s+<(.*)>");
         int cnt = sec.getLineCount();
         int state = STATE_INIT;
@@ -167,8 +167,10 @@ public final class StackTraceScanner {
                         long pc = Long.parseLong(m.group(1), 16);
                         String fileName = m.group(2);
                         String method = (m.groupCount() >= 3) ? m.group(3) : null;
-                        int methodOffset = (method == null) ? -1 : Integer.parseInt(m.group(4));
-                        StackTraceItem item = new StackTraceItem(pc, fileName, method, methodOffset);
+                        int methodOffset =  (method == null) ? -1 : Integer.parseInt(m.group(4));
+                        long offset = (m.groupCount() >= 6 && m.group(6) != null) ? Long.parseLong(m.group(6), 16) : -1;
+
+                        StackTraceItem item = (offset != -1) ? new StackTraceItem(pc, fileName, offset) : new StackTraceItem(pc, fileName, method, methodOffset);
                         curStackTrace.addStackTraceItem(item);
                     }
             }

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -42,8 +42,8 @@ import java.util.regex.Pattern;
     }
 
     public Processes scan(BugReportModule br, int id, Section sec, String chapterName) {
-        Pattern pNat = Pattern.compile("  #..  pc (........)  ([^() ]+)(?: \\((.*)\\+(.*)\\))?");
-        Pattern pNatAlt = Pattern.compile("  #..  pc (........)  ([^() ]+) \\(deleted\\)");
+        Pattern pNat = Pattern.compile("\\s+#\\d+\\s+pc\\s+([\\da-f]+)\\s+([^() ]+)\\s+(?:\\((.*)\\+(\\d+)\\))?\\s?+\\(BuildId:\\s(.*)\\)");
+        Pattern pNatAlt = Pattern.compile("\\s+#..  pc (........)  ([^() ]+) \\(deleted\\)");
         int cnt = sec.getLineCount();
         int state = STATE_INIT;
         Processes processes = new Processes(br, id, chapterName, sec.getName());
@@ -149,7 +149,7 @@ import java.util.regex.Pattern;
                             StackTraceItem item = new StackTraceItem(method, fileName, line);
                             curStackTrace.addStackTraceItem(item);
                         }
-                    } else if (buff.startsWith("  #")) {
+                    } else if (buff.trim().startsWith("#")) {
                         Matcher m = pNat.matcher(buff);
                         if (!m.matches()) {
                             m = pNatAlt.matcher(buff);

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -147,7 +147,7 @@ public final class StackTraceScanner {
                                 try {
                                     line = Integer.parseInt(lineS);
                                 } catch(NumberFormatException e) {
-                                    br.printErr(4, "Inserting raw line for unparsable: " + buff);
+                                    br.printOut(4, "Inserting raw line for unparsable: " + buff);
                                 }
                             }
                             StackTraceItem item = (fileName != null && line != -1)

--- a/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
+++ b/core/src/com/sonyericsson/chkbugreport/plugins/stacktrace/StackTraceScanner.java
@@ -28,8 +28,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.sonyericsson.chkbugreport.plugins.stacktrace.StackTraceItem.TYPE_JAVA;
-
 /**
  * This class is responsible to scan the stack trace output and collect the data
  */
@@ -152,7 +150,7 @@ public final class StackTraceScanner {
                             }
                             StackTraceItem item = (fileName != null && line != -1)
                                 ? new StackTraceItem(method, fileName, line)
-                                : new StackTraceItem(buff.substring(buff.indexOf("at ") + 3), TYPE_JAVA);
+                                : new StackTraceItem(buff.substring(buff.indexOf("at ") + 3), StackTraceItem.Type.JAVA);
 
                             curStackTrace.addStackTraceItem(item);
                         }

--- a/core/test/StackTraceScannerTest.java
+++ b/core/test/StackTraceScannerTest.java
@@ -1,0 +1,218 @@
+import com.sonyericsson.chkbugreport.BugReportModule;
+import com.sonyericsson.chkbugreport.Context;
+import com.sonyericsson.chkbugreport.Section;
+import com.sonyericsson.chkbugreport.plugins.stacktrace.*;
+import com.sonyericsson.chkbugreport.plugins.stacktrace.Process;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertEquals;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class StackTraceScannerTest {
+
+        StackTraceScanner spySut;
+        BugReportModule mockBugReport;
+        TestSection fakeVMTraceJustNow;
+
+        @Before
+        public void setup() {
+            StackTracePlugin fakeStackTracePlugin = spy(StackTracePlugin.class);
+            StackTraceScanner sut = new StackTraceScanner(fakeStackTracePlugin);
+            Context mockContext = mock(Context.class);
+            spySut = spy(sut);
+            mockBugReport = mock(BugReportModule.class);
+            when(mockBugReport.getContext()).thenReturn(mockContext);
+            fakeVMTraceJustNow = new TestSection(mockBugReport, Section.VM_TRACES_JUST_NOW);
+            fakeVMTraceJustNow.clear();
+            when(mockBugReport.findSection(Section.VM_TRACES_JUST_NOW)).thenReturn(fakeVMTraceJustNow);
+        }
+
+
+
+    @Test
+        public void instantiates() {
+            assertNotEquals(null, spySut);
+        }
+
+        @Test
+        public void parsesStacktraceOfPC() {
+            final String VM_TRACES_NOW_DATA = "----- pid 123 at 2020-01-16 14:18:55 -----\n" +
+                    "Cmd line: /system/bin/vold\n" +
+                    "ABI: 'arm64'\n" +
+                    "\n" +
+                    "\"Binder:595_2\" sysTid=595\n" +
+                    "    #00 pc 00000000000d1404  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+4) (BuildId: 4ac85d8f66f3a910f00f4ebf4d6bcd1a)\n" +
+                    "    #01 pc 000000000008ba28  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+132) (BuildId: 4ac85d8f66f3a910f00f4ebf4d6bcd1a)\n" +
+                    "    #02 pc 0000000000058d14  /system/lib64/libbinder.so (android::IPCThreadState::talkWithDriver(bool)+244) (BuildId: aa80b3412b3940b77644711e1b0057cd)\n" +
+                    "    #03 pc 0000000000058ef0  /system/lib64/libbinder.so (android::IPCThreadState::getAndExecuteCommand()+24) (BuildId: aa80b3412b3940b77644711e1b0057cd)\n" +
+                    "    #04 pc 00000000000596c8  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool(bool)+64) (BuildId: aa80b3412b3940b77644711e1b0057cd)\n" +
+                    "    #05 pc 0000000000028a7c  /system/bin/vold (main+2604) (BuildId: 51c60340a0443417335be50c68cef511)\n" +
+                    "    #06 pc 000000000007e898  /apex/com.android.runtime/lib64/bionic/libc.so (__libc_init+108) (BuildId: 4ac85d8f66f3a910f00f4ebf4d6bcd1a)";
+
+            fakeVMTraceJustNow.setTestLines(VM_TRACES_NOW_DATA);
+            Processes result = spySut.scan(mockBugReport, 0, fakeVMTraceJustNow, "test");
+
+            Process process = result.findPid(123);
+            assertNotNull(process);
+
+            StackTrace trace = process.findTid(595);
+            assertNotNull(trace);
+
+            assertEquals(7, trace.getCount());
+
+            assertEquals(Long.parseLong("00000000000d1404", 16), trace.get(0).getPC());
+            assertEquals("/apex/com.android.runtime/lib64/bionic/libc.so", trace.get(0).getFileName());
+            assertEquals("__ioctl", trace.get(0).getMethod());
+            assertEquals(4, trace.get(0).getMethodOffset());
+
+            assertEquals(Long.parseLong("00000000000596c8", 16), trace.get(4).getPC());
+            assertEquals("/system/lib64/libbinder.so", trace.get(4).getFileName());
+            assertEquals("android::IPCThreadState::joinThreadPool(bool)", trace.get(4).getMethod());
+            assertEquals(64, trace.get(4).getMethodOffset());
+        }
+
+
+    @Test
+    public void parsesStacktraceOfPCWithoutMethod() {
+        final String VM_TRACES_NOW_DATA = "----- pid 123 at 2020-01-16 14:18:55 -----\n" +
+                "Cmd line: /system/bin/vold\n" +
+                "ABI: 'arm64'\n" +
+                "\n" +
+                "\"provider@1.0-se\" sysTid=1315\n" +
+                "    #00 pc 0005ba34  /apex/com.android.runtime/lib/bionic/libc.so (syscall+28) (BuildId: d1fecf2d89af3c283776c99c1e5a0df2)\n" +
+                "    #01 pc 0003853c  /vendor/lib/libsymphony-cpu.so (BuildId: ea7604c242e0ab77e8e999724e087573029569bd)\n" +
+                "    #02 pc 000380c0  /vendor/lib/libsymphony-cpu.so (BuildId: ea7604c242e0ab77e8e999724e087573029569bd)";
+
+        fakeVMTraceJustNow.setTestLines(VM_TRACES_NOW_DATA);
+        Processes result = spySut.scan(mockBugReport, 0, fakeVMTraceJustNow, "test");
+
+        Process process = result.findPid(123);
+        assertNotNull(process);
+
+        StackTrace trace = process.findTid(1315);
+        assertNotNull(trace);
+
+        assertEquals(3, trace.getCount());
+
+        assertEquals(Long.parseLong("0005ba34", 16), trace.get(0).getPC());
+        assertEquals("/apex/com.android.runtime/lib/bionic/libc.so", trace.get(0).getFileName());
+        assertEquals("syscall", trace.get(0).getMethod());
+        assertEquals(28, trace.get(0).getMethodOffset());
+
+        assertEquals(Long.parseLong("0003853c", 16), trace.get(1).getPC());
+        assertEquals("/vendor/lib/libsymphony-cpu.so", trace.get(1).getFileName());
+        assertEquals(null, trace.get(1).getMethod());
+        assertEquals(-1, trace.get(1).getMethodOffset()); // -1 is unknown
+    }
+
+    @Test
+    public void parsesStacktraceOfPCWithAnonymous() {
+        final String VM_TRACES_NOW_DATA = "----- pid 123 at 2020-01-16 14:18:55 -----\n" +
+                "Cmd line: /system/bin/vold\n" +
+                "ABI: 'arm64'\n" +
+                "\n" +
+                "\"drmserver\" sysTid=1332\n" +
+                "    #00 pc 0009a564  /apex/com.android.runtime/lib/bionic/libc.so (__ioctl+8) (BuildId: d1fecf2d89af3c283776c99c1e5a0df2)\n" +
+                "    #01 pc 0006602d  /apex/com.android.runtime/lib/bionic/libc.so (ioctl+28) (BuildId: d1fecf2d89af3c283776c99c1e5a0df2)\n" +
+                "    #02 pc 0003b037  /system/lib/libbinder.so (android::IPCThreadState::talkWithDriver(bool)+206) (BuildId: 758775d771244cf7fd11c20197770c6b)\n" +
+                "    #03 pc 0003b18d  /system/lib/libbinder.so (android::IPCThreadState::getAndExecuteCommand()+8) (BuildId: 758775d771244cf7fd11c20197770c6b)\n" +
+                "    #04 pc 0003b77f  /system/lib/libbinder.so (android::IPCThreadState::joinThreadPool(bool)+38) (BuildId: 758775d771244cf7fd11c20197770c6b)\n" +
+                "    #05 pc 0000408f  /system/bin/drmserver (main+74) (BuildId: 664e0fa664fb9d4d3395121e7a146f00)\n" +
+                "    #06 pc 0005ab61  /apex/com.android.runtime/lib/bionic/libc.so (__libc_init+68) (BuildId: d1fecf2d89af3c283776c99c1e5a0df2)\n" +
+                "    #07 pc 0000402f  /system/bin/drmserver (_start_main+38) (BuildId: 664e0fa664fb9d4d3395121e7a146f00)\n" +
+                "    #08 pc 00004456  <anonymous:f5f08000>";
+
+        fakeVMTraceJustNow.setTestLines(VM_TRACES_NOW_DATA);
+        Processes result = spySut.scan(mockBugReport, 0, fakeVMTraceJustNow, "test");
+
+        Process process = result.findPid(123);
+        assertNotNull(process);
+
+        StackTrace trace = process.findTid(1332);
+        assertNotNull(trace);
+
+        assertEquals(9, trace.getCount());
+
+        assertEquals(Long.parseLong("0009a564", 16), trace.get(0).getPC());
+        assertEquals("/apex/com.android.runtime/lib/bionic/libc.so", trace.get(0).getFileName());
+        assertEquals("__ioctl", trace.get(0).getMethod());
+        assertEquals(8, trace.get(0).getMethodOffset());
+
+        assertEquals(Long.parseLong("00004456", 16), trace.get(8).getPC());
+        assertEquals("anonymous:f5f08000", trace.get(8).getFileName());
+        assertEquals(null, trace.get(8).getMethod());
+        assertEquals(-1, trace.get(8).getMethodOffset()); // -1 is unknown
+    }
+
+    @Test
+    public void parsesStacktraceOfPCWithNative() {
+        final String VM_TRACES_NOW_DATA = "----- pid 123 at 2020-01-16 14:18:55 -----\n" +
+                "Cmd line: /system/bin/vold\n" +
+                "ABI: 'arm64'\n" +
+                "\n" +
+                "DALVIK THREADS (23):\n" +
+                "\"Signal Catcher\" daemon prio=5 tid=7 Runnable\n" +
+                "  | group=\"system\" sCount=0 dsCount=0 flags=0 obj=0x13580228 self=0x741052c400\n" +
+                "  | sysTid=7094 nice=0 cgrp=default sched=0/0 handle=0x7416244d50\n" +
+                "  | state=R schedstat=( 34420882 4547760 7 ) utm=2 stm=1 core=2 HZ=100\n" +
+                "  | stack=0x741614e000-0x7416150000 stackSize=991KB\n" +
+                "  | held mutexes= \"mutator lock\"(shared held)\n" +
+                "  native: #00 pc 00000000004118ec  /apex/com.android.runtime/lib64/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, int, BacktraceMap*, char const*, art::ArtMethod*, void*, bool)+140)\n" +
+                "  (no managed stack frames)";
+
+        fakeVMTraceJustNow.setTestLines(VM_TRACES_NOW_DATA);
+        Processes result = spySut.scan(mockBugReport, 0, fakeVMTraceJustNow, "test");
+
+        Process process = result.findPid(123);
+        assertNotNull(process);
+
+        StackTrace trace = process.findTid(7);
+        assertNotNull(trace);
+
+        assertEquals(1, trace.getCount());
+
+        assertEquals(Long.parseLong("00000000004118ec", 16), trace.get(0).getPC());
+        assertEquals("/apex/com.android.runtime/lib64/libart.so", trace.get(0).getFileName());
+        assertEquals("art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, int, BacktraceMap*, char const*, art::ArtMethod*, void*, bool)", trace.get(0).getMethod());
+        assertEquals(140, trace.get(0).getMethodOffset());
+    }
+
+    @Test
+    public void parsesStacktraceOfPCWithOffset() {
+        final String VM_TRACES_NOW_DATA = "----- pid 123 at 2020-01-16 14:18:55 -----\n" +
+                "Cmd line: /system/bin/vold\n" +
+                "ABI: 'arm64'\n" +
+                "\n" +
+                "\"ChromiumNet\" prio=5 tid=52 Native\n" +
+                "  | group=\"main\" sCount=1 dsCount=0 flags=1 obj=0x154c3790 self=0x73b38d7000\n" +
+                "  | sysTid=16601 nice=-2 cgrp=default sched=0/0 handle=0x738bff6d50\n" +
+                "  | state=S schedstat=( 5138957 4233386 18 ) utm=0 stm=0 core=0 HZ=100\n" +
+                "  | stack=0x738bf00000-0x738bf02000 stackSize=991KB\n" +
+                "  | held mutexes=\n" +
+                "  kernel: (couldn't read /proc/self/task/16601/stack)\n" +
+                "  native: #00 pc 00000000000d12c8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8)\n" +
+                "  native: #01 pc 000000000035a18c  /system/product/priv-app/Velvet/Velvet.apk!libcronet.80.0.3955.6.so (offset 64e4000) (???)";
+
+        fakeVMTraceJustNow.setTestLines(VM_TRACES_NOW_DATA);
+        Processes result = spySut.scan(mockBugReport, 0, fakeVMTraceJustNow, "test");
+
+        Process process = result.findPid(123);
+        assertNotNull(process);
+
+        StackTrace trace = process.findTid(52);
+        assertNotNull(trace);
+
+        assertEquals(2, trace.getCount());
+
+        assertEquals(Long.parseLong("000000000035a18c", 16), trace.get(1).getPC());
+        assertEquals("/system/product/priv-app/Velvet/Velvet.apk!libcronet.80.0.3955.6.so", trace.get(1).getFileName());
+        assertEquals(null, trace.get(1).getMethod());
+        assertEquals(Long.parseLong("64e4000", 16), trace.get(1).getOffset());
+    }
+}


### PR DESCRIPTION
Skip over missing line numbers, not all stack traces have correct line numbers:

```
"highpool[0]" prio=5 tid=21 Waiting
  | group="main" sCount=1 dsCount=0 flags=1 obj=0x12f00848 self=0x70daf59000
  | sysTid=2094 nice=9 cgrp=default sched=0/0 handle=0x7073bc4d50
  | state=S schedstat=( 2427913 393338 14 ) utm=0 stm=0 core=4 HZ=100
  | stack=0x7073ac2000-0x7073ac4000 stackSize=1039KB
  | held mutexes=
  at sun.misc.Unsafe.park(Native method)
  - waiting on an unknown object
  at java.util.concurrent.locks.LockSupport.park(LockSupport.java:190)
  at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:459)
  at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:362)
  at java.util.concurrent.SynchronousQueue.take(SynchronousQueue.java:920)
  at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1092)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1152)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
  at tcn.run(:com.google.android.gms@19629037@19.6.29 (120400-278422107):-1)
  at java.lang.Thread.run(Thread.java:919)
```

This PR does not actually attempt to parse these lines, it just prints that it's skipping over them in the parsing log.