### PR TITLE
Enable actions on pull requests

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,6 +1,6 @@
 name: Java CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
It seems that actions do not run on pull requests from other repos by
default since the push has not yet occured on this repo.  This should
explicitly enable PR's to have the CI steps run on them.