### PR TITLE
Bump the version

### DIFF
--- a/core/src/com/sonyericsson/chkbugreport/Module.java
+++ b/core/src/com/sonyericsson/chkbugreport/Module.java
@@ -71,7 +71,7 @@ public abstract class Module implements ChapterParent {
      * The incremental release number of the application
      * (this number is always incremented, never reset or decremented)
      */
-    public static final String VERSION_CODE = "216";
+    public static final String VERSION_CODE = "217";
 
     /** The name of the file where the output will be logged */
     private static final String LOG_NAME = "chkbugreport_log.txt";


### PR DESCRIPTION
Given new log parsing features (a quite noticable change) we will bump
the VERSION_CODE to 217 so we can differentiate this from other builds.