### PR TITLE
Enable archiving of build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,3 +15,8 @@ jobs:
         java-version: 1.8
     - name: Build core and unit test with gradle
       run: cd core && ./gradlew build
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: ChkBugReport
+        path: core/build/distributions/ChkBugReport.tar


### PR DESCRIPTION
Save the build so that it can be downloaded if needed.