### PR TITLE
Create main class item in manifest.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -46,6 +46,13 @@ sourceSets {
 
 application {
     mainClassName = 'com.sonyericsson.chkbugreport.Main'
+    jar {
+        manifest {
+            attributes(
+                'Main-Class': mainClassName
+            )
+        }
+    }
 }
 
 test {


### PR DESCRIPTION
This is expected by some pre-existing tools and the new gradle build
does not include it by default.