### PR TITLE
Fix section parsing

### DIFF
--- a/core/src/com/sonyericsson/chkbugreport/BugReportModule.java
+++ b/core/src/com/sonyericsson/chkbugreport/BugReportModule.java
@@ -215,7 +215,7 @@ public class BugReportModule extends Module {
             if (buff.startsWith("------ ")) {
                 // build up file name
                 int e = buff.indexOf(" ------");
-                if (e >= 0) {
+                if (e >= 0 && !buff.contains("was the duration of")) {  //Filter out durations so they aren't new sections
                     String sectionName = buff.substring(7, e);
 
                     // Workaround for SMAP spamming
@@ -247,6 +247,10 @@ public class BugReportModule extends Module {
                 // Another kind of marker
                 // Need to read the next line
                 String sectionName = br.readLine();
+                if(sectionName.equals(SECTION_DIVIDER)) {
+                    //Empty section try the next line.
+                    sectionName = br.readLine();
+                }
                 if (sectionName != null) {
                     if ("DUMP OF SERVICE activity:".equals(sectionName)) {
                         // skip over this name, and use the next line as title, the provider thingy


### PR DESCRIPTION
Some sections where not found.  Others where added that are not actually
sections.

This fixes the sections like : 
```
6.451s was the duration of 'DUMPSYS' 
5.101s was the duration of 'DUMPSYS PROTO'
```

And now finds the section: 
```
WINDOW MANAGER DISPLAY CONTENTS (dumpsys window displays)
```